### PR TITLE
Update Version and automatically set last version in User-Agent

### DIFF
--- a/stuart-client-csharp/Version.cs
+++ b/stuart-client-csharp/Version.cs
@@ -1,28 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace StuartDelivery
 {
-    public class Version
+    public static class Version
     {
 
-        public string GetCurrent()
+        public static string GetCurrent()
         {
-            //InputStream resourceAsStream = this.getClass().getResourceAsStream("/version.properties");
-            //Properties prop = new Properties();
-            //try
-            //{
-            //    prop.load(resourceAsStream);
-            //}
-            //catch (IOException e)
-            //{
-            //    e.printStackTrace();
-            //}
-            //return prop.getProperty("version");
-            throw new NotImplementedException();
+            try {
+                return Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            }
+            catch (Exception) {
+                // Use default version
+                return "1.0";
+            }
         }
     }
 }

--- a/stuart-client-csharp/WebClient.cs
+++ b/stuart-client-csharp/WebClient.cs
@@ -14,7 +14,7 @@ namespace StuartDelivery
         public WebClient(Environment environment)
         {
             _client = new HttpClient { BaseAddress = new Uri($"{environment.BaseUrl}") };
-            _client.DefaultRequestHeaders.Add("User-Agent", "stuart-client-csharp/1.3.1");
+            _client.DefaultRequestHeaders.Add("User-Agent", $"stuart-client-csharp/{Version.GetCurrent()}");
         }
 
         public void SetAuthorization(string token)


### PR DESCRIPTION
The `Version` class now loads the client version using reflection on the executing assembly.
`WebClient` automatically sets the `User-Agent` default header with the correct version on initialization.