### PR TITLE
Fix token expiration

### DIFF
--- a/stuart-client-csharp/Authenticator.cs
+++ b/stuart-client-csharp/Authenticator.cs
@@ -50,10 +50,13 @@ namespace StuartDelivery
             else
                 throw new HttpRequestException($"Access token request failed with message: {response.Content.ReadAsAsync<ErrorResponse>().Result.ErrorDescription}");
 
+            var createdAt = DateTimeOffset.FromUnixTimeSeconds(tokenResponse.CreatedAt);
+            var expiresAt = createdAt.AddSeconds(tokenResponse.ExpiresIn);
+
             return new OAuth2AccessToken()
             {
                 AccessToken = tokenResponse.AccessToken,
-                ExpireDate = DateTime.UtcNow.AddMinutes(tokenResponse.ExpiresIn),
+                ExpireDate = expiresAt.UtcDateTime,
                 Scope = tokenResponse.Scope,
                 TokenType = tokenResponse.TokenType
             };


### PR DESCRIPTION
Bugfix for how token expiration is computed: according to the [Stuart API documentation](https://stuart.api-docs.io/v2/authentication/get-oauth2-access-token), the `expires_in` field describes the token lifetime, expressed in seconds. The updated code correctly determines the token's lifetime by adding seconds to the actual creation timestamp.