### PR TITLE
Add support for webhook management APIs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+csharp_new_line_before_open_brace = all

--- a/stuart-client-csharp-tests/WebhookTests.cs
+++ b/stuart-client-csharp-tests/WebhookTests.cs
@@ -1,9 +1,8 @@
 ﻿using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using StuartDelivery.Models.Webhook.Enums;
 using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace StuartDelivery.Tests
@@ -60,21 +59,54 @@ namespace StuartDelivery.Tests
             result.Error.Error.Should().BeEquivalentTo("NOT_FOUND");
         }
 
+        [TestMethod]
+        public async Task CreateWebhook_Should_RespectWebhookTopics()
+        {
+            var spec = CreateWebhookSpec();
+            spec.Topics = new WebhookTopic[]
+            {
+                WebhookTopic.JobCreate
+            };
+            var createResult = await StuartApi.Webhook.Create(spec);
+
+            createResult.Data.Should().NotBeNull();
+            createResult.Data.Id.Should().BeGreaterThan(0);
+            createResult.Data.Topics.Length.Should().Be(1);
+            createResult.Data.Topics[0].Should().Be(WebhookTopic.JobCreate);
+
+            var infoResult = await StuartApi.Webhook.Get(createResult.Data.Id);
+
+            infoResult.Data.Id.Should().Be(createResult.Data.Id);
+            infoResult.Data.Topics.Length.Should().Be(1);
+            infoResult.Data.Topics[0].Should().Be(WebhookTopic.JobCreate);
+
+            var listResult = await StuartApi.Webhook.GetList();
+            listResult.Data.Should().NotBeNull();
+            listResult.Data.Length.Should().BeGreaterOrEqualTo(1);
+            var webhookFromList = listResult.Data.SingleOrDefault(h => h.Id == createResult.Data.Id);
+            webhookFromList.Should().NotBeNull();
+            webhookFromList.Topics.Length.Should().Be(1);
+            webhookFromList.Topics[0].Should().Be(WebhookTopic.JobCreate);
+
+            var deleteResult = await StuartApi.Webhook.Delete(createResult.Data.Id);
+
+            deleteResult.Data.Should().BeTrue();
+        }
+
         private Models.Webhook.Request.Webhook CreateWebhookSpec()
         {
             return new Models.Webhook.Request.Webhook
             {
                 Url = "https://example.org/" + Guid.NewGuid().ToString("N"),
                 Enabled = true,
-                Topics = new string[]
-                {
-                    "job/create",
-                    "job/update",
-                    "delivery/create",
-                    "delivery/update",
-                    "driver/update",
-                    "driver/online",
-                    "driver/offline"
+                Topics = new WebhookTopic[] {
+                    WebhookTopic.JobCreate,
+                    WebhookTopic.JobUpdate,
+                    WebhookTopic.DeliveryCreate,
+                    WebhookTopic.DeliveryUpdate,
+                    WebhookTopic.DriverUpdate,
+                    WebhookTopic.DriverOnline,
+                    WebhookTopic.DriverOffline
                 },
                 AuthenticationHeader = "X-My-Header",
                 AuthenticationKey = "abc123" + _random.Next()

--- a/stuart-client-csharp-tests/WebhookTests.cs
+++ b/stuart-client-csharp-tests/WebhookTests.cs
@@ -28,14 +28,16 @@ namespace StuartDelivery.Tests
 
             createResult.Data.Should().NotBeNull();
             createResult.Data.Id.Should().BeGreaterThan(0);
+            createResult.Data.Url.Should().Be(spec.Url);
 
             var infoResult = await StuartApi.Webhook.Get(createResult.Data.Id);
 
-            infoResult.Data.Id.Should().Equals(createResult.Data.Id);
-            infoResult.Data.Url.Should().Equals(spec.Url);
-            infoResult.Data.Enabled.Should().Equals(spec.Enabled);
-            infoResult.Data.AuthenticationHeader.Should().Equals(spec.AuthenticationHeader);
-            infoResult.Data.AuthenticationKey.Should().Equals(spec.AuthenticationKey);
+            infoResult.Data.Should().NotBeNull();
+            infoResult.Data.Id.Should().Be(createResult.Data.Id);
+            infoResult.Data.Url.Should().Be(spec.Url);
+            infoResult.Data.Enabled.Should().Be(spec.Enabled);
+            infoResult.Data.AuthenticationHeader.Should().Be(spec.AuthenticationHeader);
+            infoResult.Data.AuthenticationKey.Should().Be(spec.AuthenticationKey);
 
             var deleteResult = await StuartApi.Webhook.Delete(createResult.Data.Id);
 
@@ -75,7 +77,7 @@ namespace StuartDelivery.Tests
                     "driver/offline"
                 },
                 AuthenticationHeader = "X-My-Header",
-                AuthenticationKey = "abc123"
+                AuthenticationKey = "abc123" + _random.Next()
             };
         }
     }

--- a/stuart-client-csharp-tests/WebhookTests.cs
+++ b/stuart-client-csharp-tests/WebhookTests.cs
@@ -1,0 +1,82 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StuartDelivery.Tests
+{
+    [TestClass]
+    public class WebhookTests : BaseTests
+    {
+        private Random _random;
+
+        [TestInitialize]
+        public override void TestInit()
+        {
+            _random = new Random();
+            base.TestInit();
+        }
+
+        [TestMethod]
+        public async Task CreateWebhook_Should_CreateAndDeleteWebhook()
+        {
+            var spec = CreateWebhookSpec();
+            var createResult = await StuartApi.Webhook.Create(spec);
+
+            createResult.Data.Should().NotBeNull();
+            createResult.Data.Id.Should().BeGreaterThan(0);
+
+            var infoResult = await StuartApi.Webhook.Get(createResult.Data.Id);
+
+            infoResult.Data.Id.Should().Equals(createResult.Data.Id);
+            infoResult.Data.Url.Should().Equals(spec.Url);
+            infoResult.Data.Enabled.Should().Equals(spec.Enabled);
+            infoResult.Data.AuthenticationHeader.Should().Equals(spec.AuthenticationHeader);
+            infoResult.Data.AuthenticationKey.Should().Equals(spec.AuthenticationKey);
+
+            var deleteResult = await StuartApi.Webhook.Delete(createResult.Data.Id);
+
+            deleteResult.Data.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task UpdateWebhook_Should_ContainError()
+        {
+            var result = await StuartApi.Webhook.Update(_random.Next(100, 1000), CreateWebhookSpec()).ConfigureAwait(false);
+            result.Error.Should().NotBeNull();
+            result.Error.Error.Should().BeEquivalentTo("NOT_FOUND");
+        }
+
+        [TestMethod]
+        public async Task DeleteWebhook_Should_ContainError()
+        {
+            var result = await StuartApi.Webhook.Delete(_random.Next(100, 1000)).ConfigureAwait(false);
+            result.Error.Should().NotBeNull();
+            result.Error.Error.Should().BeEquivalentTo("NOT_FOUND");
+        }
+
+        private Models.Webhook.Request.Webhook CreateWebhookSpec()
+        {
+            return new Models.Webhook.Request.Webhook
+            {
+                Url = "https://example.org/" + Guid.NewGuid().ToString("N"),
+                Enabled = true,
+                Topics = new string[]
+                {
+                    "job/create",
+                    "job/update",
+                    "delivery/create",
+                    "delivery/update",
+                    "driver/update",
+                    "driver/online",
+                    "driver/offline"
+                },
+                AuthenticationHeader = "X-My-Header",
+                AuthenticationKey = "abc123"
+            };
+        }
+    }
+}

--- a/stuart-client-csharp/Abstract/IWebhook.cs
+++ b/stuart-client-csharp/Abstract/IWebhook.cs
@@ -1,0 +1,37 @@
+﻿using StuartDelivery.Models;
+using System.Threading.Tasks;
+using WebhookRequest = StuartDelivery.Models.Webhook.Request;
+using WebhookResponse = StuartDelivery.Models.Webhook.Response;
+
+namespace StuartDelivery.Abstract
+{
+    public interface IWebhook
+    {
+        /// <summary>
+        /// This endpoint allows you to create a webhook through the Stuart API.
+        /// </summary>
+        Task<Result<WebhookResponse.Webhook>> Create(WebhookRequest.Webhook webhook);
+
+        /// <summary>
+        /// This endpoint will return a list of your current webhooks.
+        /// Currently, you are able to have a maximum of 6 webhooks.
+        /// </summary>
+        Task<Result<WebhookResponse.Webhook[]>> GetList();
+
+        /// <summary>
+        /// This endpoint allows you to get information on a specific webhook that you have
+        /// created using the <see cref="Create(WebhookRequest.Webhook)"/> method.
+        /// </summary>
+        Task<Result<WebhookResponse.Webhook>> Get(int webhookId);
+
+        /// <summary>
+        /// This endpoint allows you to update any webhooks you have created.
+        /// </summary>
+        Task<Result<WebhookResponse.Webhook>> Update(int webhookId, WebhookRequest.Webhook webhook);
+
+        /// <summary>
+        /// This endpoint allows you to delete a particular webhook.
+        /// </summary>
+        Task<Result<bool>> Delete(int webhookId);
+    }
+}

--- a/stuart-client-csharp/Concrete/Webhook.cs
+++ b/stuart-client-csharp/Concrete/Webhook.cs
@@ -1,0 +1,133 @@
+﻿using StuartDelivery.Abstract;
+using StuartDelivery.Models;
+using System;
+using System.Dynamic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using WebhookRequest = StuartDelivery.Models.Webhook.Request;
+using WebhookResponse = StuartDelivery.Models.Webhook.Response;
+
+namespace StuartDelivery.Concrete
+{
+    class Webhook : IWebhook
+    {
+        private readonly WebClient _webClient;
+
+        public Webhook(WebClient webClient)
+        {
+            _webClient = webClient;
+        }
+
+        public async Task<Result<WebhookResponse.Webhook>> Create(WebhookRequest.Webhook webhook)
+        {
+            try
+            {
+                var response = await _webClient.PostAsync("/v2/webhooks", webhook).ConfigureAwait(false);
+                var result = new Result<WebhookResponse.Webhook>();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    result.Data = await response.Content.ReadAsAsync<WebhookResponse.Webhook>().ConfigureAwait(false);
+                    return result;
+                }
+
+                result.Error = await response.Content.ReadAsAsync<ErrorResponse>();
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw new HttpRequestException($"{nameof(Create)} failed", e);
+            }
+        }
+
+        public async Task<Result<bool>> Delete(int webhookId)
+        {
+            try
+            {
+                var response = await _webClient.DeleteAsync($"/v2/webhooks/{webhookId}").ConfigureAwait(false);
+                var result = new Result<bool>();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var obj = await response.Content.ReadAsAsync<ExpandoObject>().ConfigureAwait(false);
+                    result.Data = (bool)obj.FirstOrDefault(x => x.Key == "success").Value;
+                    return result;
+                }
+
+                result.Error = response.Content.ReadAsAsync<ErrorResponse>().Result;
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw new HttpRequestException($"{nameof(Delete)} failed", e);
+            }
+        }
+
+        public async Task<Result<WebhookResponse.Webhook>> Get(int webhookId)
+        {
+            try
+            {
+                var response = await _webClient.GetAsync($"/v2/webhooks/{webhookId}").ConfigureAwait(false);
+                var result = new Result<WebhookResponse.Webhook>();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    result.Data = await response.Content.ReadAsAsync<WebhookResponse.Webhook>().ConfigureAwait(false);
+                    return result;
+                }
+
+                result.Error = response.Content.ReadAsAsync<ErrorResponse>().Result;
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw new HttpRequestException($"{nameof(Get)} failed", e);
+            }
+        }
+
+        public async Task<Result<WebhookResponse.Webhook[]>> GetList()
+        {
+            try
+            {
+                var response = await _webClient.GetAsync($"/v2/webhooks").ConfigureAwait(false);
+                var result = new Result<WebhookResponse.Webhook[]>();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    result.Data = await response.Content.ReadAsAsync<WebhookResponse.Webhook[]>().ConfigureAwait(false);
+                    return result;
+                }
+
+                result.Error = response.Content.ReadAsAsync<ErrorResponse>().Result;
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw new HttpRequestException($"{nameof(GetList)} failed", e);
+            }
+        }
+
+        public async Task<Result<WebhookResponse.Webhook>> Update(int webhookId, WebhookRequest.Webhook webhook)
+        {
+            try
+            {
+                var response = await _webClient.PutAsync($"/v2/webhooks/{webhookId}", webhook).ConfigureAwait(false);
+                var result = new Result<WebhookResponse.Webhook>();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    result.Data = await response.Content.ReadAsAsync<WebhookResponse.Webhook>().ConfigureAwait(false);
+                    return result;
+                }
+
+                result.Error = response.Content.ReadAsAsync<ErrorResponse>().Result;
+                return result;
+            }
+            catch (Exception e)
+            {
+                throw new HttpRequestException($"{nameof(Update)} failed", e);
+            }
+        }
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Enums/WebhookTopic.cs
+++ b/stuart-client-csharp/Models/Webhook/Enums/WebhookTopic.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StuartDelivery.Models.Webhook.Enums
+{
+    public enum WebhookTopic
+    {
+        JobCreate,
+        JobUpdate,
+        DeliveryCreate,
+        DeliveryUpdate,
+        DriverUpdate,
+        DriverOnline,
+        DriverOffline
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Enums/WebhookTopicArrayJsonConverter.cs
+++ b/stuart-client-csharp/Models/Webhook/Enums/WebhookTopicArrayJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StuartDelivery.Models.Webhook.Enums
+{
+    class WebhookTopicArrayJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            if(typeof(WebhookTopic[]).IsAssignableFrom(objectType))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            WebhookTopic[] arr = (WebhookTopic[])value;
+            writer.WriteStartArray();
+            for(int i = 0; i < arr.Length; ++i)
+            {
+                writer.WriteValue(arr[i].ToApiString());
+            }
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Enums/WebhookTopicExtensions.cs
+++ b/stuart-client-csharp/Models/Webhook/Enums/WebhookTopicExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace StuartDelivery.Models.Webhook.Enums
+{
+    public static class WebhookTopicExtensions
+    {
+        private static readonly Dictionary<WebhookTopic, string> _enumMap;
+        private static readonly Dictionary<string, WebhookTopic> _stringMap;
+
+        static WebhookTopicExtensions()
+        {
+            _enumMap = new Dictionary<WebhookTopic, string>
+            {
+                { WebhookTopic.JobCreate, "job/create" },
+                { WebhookTopic.JobUpdate, "job/update" },
+                { WebhookTopic.DeliveryCreate, "delivery/create" },
+                { WebhookTopic.DeliveryUpdate, "delivery/update" },
+                { WebhookTopic.DriverUpdate, "driver/update" },
+                { WebhookTopic.DriverOnline, "driver/online" },
+                { WebhookTopic.DriverOffline, "driver/offline" },
+            };
+
+            _stringMap = new Dictionary<string, WebhookTopic>(_enumMap.Count);
+            foreach(var pair in _enumMap)
+            {
+                _stringMap[pair.Value] = pair.Key;
+            }
+        }
+
+        public static string ToApiString(this WebhookTopic topic)
+        {
+            if(!_enumMap.ContainsKey(topic))
+            {
+                throw new ArgumentOutOfRangeException(nameof(topic), $"Webhook topic {topic} not valid");
+            }
+
+            return _enumMap[topic];
+        }
+
+        public static WebhookTopic FromApiString(this string s)
+        {
+            if (!_stringMap.ContainsKey(s))
+            {
+                throw new ArgumentOutOfRangeException(nameof(s), $"Webhook topic {s} not valid");
+            }
+
+            return _stringMap[s];
+        }
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Request/Webhook.cs
+++ b/stuart-client-csharp/Models/Webhook/Request/Webhook.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StuartDelivery.Models.Webhook.Request
+{
+    public class Webhook
+    {
+        [JsonProperty(PropertyName = "url")]
+        [JsonRequired]
+        public string Url { get; set; }
+
+        [JsonProperty(PropertyName = "topics")]
+        [JsonRequired]
+        public string[] Topics { get; set; } = new string[0];
+
+        [JsonProperty(PropertyName = "enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonProperty(PropertyName = "authentication_header")]
+        public string AuthenticationHeader { get; set; }
+
+        [JsonProperty(PropertyName = "authentication_key")]
+        public string AuthenticationKey { get; set; }
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Request/Webhook.cs
+++ b/stuart-client-csharp/Models/Webhook/Request/Webhook.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using StuartDelivery.Models.Webhook.Enums;
 
 namespace StuartDelivery.Models.Webhook.Request
 {
@@ -13,7 +11,8 @@ namespace StuartDelivery.Models.Webhook.Request
 
         [JsonProperty(PropertyName = "topics")]
         [JsonRequired]
-        public string[] Topics { get; set; } = new string[0];
+        [JsonConverter(typeof(WebhookTopicArrayJsonConverter))]
+        public WebhookTopic[] Topics { get; set; } = new WebhookTopic[0];
 
         [JsonProperty(PropertyName = "enabled")]
         public bool Enabled { get; set; }

--- a/stuart-client-csharp/Models/Webhook/Response/Webhook.cs
+++ b/stuart-client-csharp/Models/Webhook/Response/Webhook.cs
@@ -1,0 +1,37 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace StuartDelivery.Models.Webhook.Response
+{
+    public class Webhook
+    {
+        [JsonProperty(PropertyName = "id")]
+        public int Id { get; set; }
+
+        [JsonProperty(PropertyName = "created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty(PropertyName = "updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string Url { get; set; }
+
+        [JsonProperty(PropertyName = "enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonProperty(PropertyName = "authentication_header")]
+        public string AuthenticationHeader { get; set; }
+
+        [JsonProperty(PropertyName = "authentication_key")]
+        public string AuthenticationKey { get; set; }
+
+        // NOTE: Ignoring property for now because the Stuart API returns data inconsistent with the documentation
+        //       (i.e., should be array of strings, but is array of objects).
+        [JsonProperty(PropertyName = "topics")]
+        [JsonIgnore]
+        public string[] Topics { get; set; } = new string[0];
+    }
+}

--- a/stuart-client-csharp/Models/Webhook/Response/Webhook.cs
+++ b/stuart-client-csharp/Models/Webhook/Response/Webhook.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
+using StuartDelivery.Models.Webhook.Enums;
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace StuartDelivery.Models.Webhook.Response
 {
@@ -28,10 +28,22 @@ namespace StuartDelivery.Models.Webhook.Response
         [JsonProperty(PropertyName = "authentication_key")]
         public string AuthenticationKey { get; set; }
 
-        // NOTE: Ignoring property for now because the Stuart API returns data inconsistent with the documentation
-        //       (i.e., should be array of strings, but is array of objects).
         [JsonProperty(PropertyName = "topics")]
+        private TopicContainer[] InnerTopics { get; set; } = new TopicContainer[0];
+
+        private class TopicContainer
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+        }
+
         [JsonIgnore]
-        public string[] Topics { get; set; } = new string[0];
+        public WebhookTopic[] Topics { get
+            {
+                return (InnerTopics ?? new TopicContainer[0])
+                    .Select(t => t.Name.FromApiString())
+                    .ToArray();
+            }
+        }
     }
 }

--- a/stuart-client-csharp/StuartApi.cs
+++ b/stuart-client-csharp/StuartApi.cs
@@ -11,9 +11,11 @@ namespace StuartDelivery
 
         private IAddress _address;
         private IJob _job;
+        private IWebhook _webhook;
 
         public IAddress Address { get { return _address ?? (_address = new Address(_client)); } }
         public IJob Job { get { return _job ?? (_job = new Job(_client)); } }
+        public IWebhook Webhook { get { return _webhook ?? (_webhook = new Webhook(_client)); } }
 
         public static StuartApi Initialize(Environment environment, string clientId, string clientSecret)
         {


### PR DESCRIPTION
Added support for [V2 webhook management APIs](https://stuart.api-docs.io/v2/webhook-management/webhooks-through-the-api).

The C# API mimics the existing code and its organization: `StuartApi.Webhook` exposes the interface `IWebhook`, implemented as `StuartDelivery.Concrete.Webhook`, exposing a set of asynchronous methods that allow users to create, update, get, fetch a list of, and delete Stuart webhooks.

A short set of tests is provided in `StuartDelivery.Tests.WebhookTests`.

Also, added an _editorconfig_ file in the root directory, to set common style rules for the project.